### PR TITLE
Use platform cancel string for better translation

### DIFF
--- a/datetimepicker-library/res/layout/picker_done_button.xml
+++ b/datetimepicker-library/res/layout/picker_done_button.xml
@@ -15,7 +15,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/view_margin_medium"
-        android:text="@string/cancel_label"
+        android:text="@android:string/cancel"
         android:layout_toStartOf="@id/done_button"
         android:layout_toLeftOf="@id/done_button"
         style="@style/button_bar_button" />

--- a/datetimepicker-library/res/values/strings.xml
+++ b/datetimepicker-library/res/values/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="http://schemas.android.com/apk/res/android">
     <string name="done_label">OK</string>
-    <string name="cancel_label">Cancel</string>
     <string name="day_picker_description">Month grid of days</string>
     <string name="year_picker_description">Year list</string>
     <string name="select_day">Select month and day</string>


### PR DESCRIPTION
I noticed that the cancel string currently used is not translated at all. Maybe we need to replace @string/done_label with @android:string/ok as well. But that string's translation is different (at least in German) from the default ok, so I left it untouched.
